### PR TITLE
Fix release name to strip ref/tag part

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,6 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          name: Release ${{ github.ref }}
+          name: Release ${{ github.ref_name }}
           artifacts: "GitWorkshop_Slides.pdf,GitWorkshop_Handout.pdf"
           generateReleaseNotes: true


### PR DESCRIPTION
github.ref_name	string	The branch or tag name that triggered the workflow run.

https://docs.github.com/en/actions/learn-github-actions/contexts